### PR TITLE
Update watch.yml

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -10,6 +10,9 @@ jobs:
   docker:
     name: Push tagged docker image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Write permissions must be explicitly granted to the job to publish content to GHCR